### PR TITLE
Add gd extension for pandoc in Dockerfile

### DIFF
--- a/docker/Dockerfile-pandoc
+++ b/docker/Dockerfile-pandoc
@@ -5,6 +5,7 @@ RUN apt-get update \
 		pandoc \
 		jq \
 		awscli \
+                libpng-dev \
 	&& apt-get clean
 
 COPY --chown=www-data:www-data pandoc/* /var/www/html/
@@ -15,6 +16,8 @@ RUN mkdir \
 	&& chown www-data:www-data \
 		/var/www/datatmp \
 		/var/www/html/imgs
+
+RUN docker-php-ext-install gd
 
 # enable php production defaults
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini


### PR DESCRIPTION
Before this change:

```
Interactive shell

php > $img = imagecreate(12,12);

Warning: Uncaught Error: Call to undefined function imagecreate() in php shell code:1
Stack trace:
#0 {main}
  thrown in php shell code on line 1
php >
```

After this change:

```
Interactive shell

php > $img = imagecreate(12,12);
php > var_dump($img);
object(GdImage)#1 (0) {
}
php >
```

✅ Tested in staging.
